### PR TITLE
Fix userInfo merge in error handling

### DIFF
--- a/BuckarooBanzai/BuckarooBanzai.swift
+++ b/BuckarooBanzai/BuckarooBanzai.swift
@@ -258,7 +258,7 @@ open class BuckarooBanzai: NSObject {
             additionalInfo.merge(userInfo) { (current, _) in
                 current
             }
-            throw error.updateUserInfoWith(userInfo: userInfo)
+            throw error.updateUserInfoWith(userInfo: additionalInfo)
         }
     }
     


### PR DESCRIPTION
## Summary
- ensure the additional HTTP response info is returned with errors

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684ef0c1798083308f678837cc03bf90